### PR TITLE
Bump Syncthing to 1.29.5

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  syncthing-source-v1.29.2.tar.gz: c769cc2fb1e3a33951f17954fc1087aae4143208
+  syncthing-source-v1.29.5.tar.gz: 0f436d5a73e77d42206dea6c8b827204  

--- a/syncthing.spec
+++ b/syncthing.spec
@@ -5,7 +5,7 @@
 
 Name:           syncthing
 Summary:        Continuous File Synchronization
-Version:        1.29.2
+Version:        1.29.5
 Release:        1
 
 %global tag     v%{version}


### PR DESCRIPTION
No change except to bump the version up to the current 1.29.5. 
