### PR TITLE
Syncthing bump release to 1.29.7

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  syncthing-source-v1.29.2.tar.gz: c769cc2fb1e3a33951f17954fc1087aae4143208
+  syncthing-source-v1.29.7.tar.gz: 49534c2b29899c30998b9a6c897f2c6f09875964

--- a/syncthing.spec
+++ b/syncthing.spec
@@ -5,7 +5,7 @@
 
 Name:           syncthing
 Summary:        Continuous File Synchronization
-Version:        1.29.2
+Version:        1.29.5
 Release:        1
 
 %global tag     v%{version}

--- a/syncthing.spec
+++ b/syncthing.spec
@@ -5,7 +5,7 @@
 
 Name:           syncthing
 Summary:        Continuous File Synchronization
-Version:        1.29.5
+Version:        1.29.7
 Release:        1
 
 %global tag     v%{version}


### PR DESCRIPTION
Successful ABF builds: 

- https://abf.openmandriva.org/build_lists/525888 (aarch64)
- https://abf.openmandriva.org/build_lists/525890 (znver1) 
- https://abf.openmandriva.org/build_lists/525889 (x86_64)
