### PR TITLE
Bump Syncthing to 2.0.1

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  syncthing-source-v2.0.0.tar.gz:   c02223db1415c83dfe9f65cb2b5d2149b98e1be8
+  syncthing-source-v2.0.1.tar.gz:   68e183b517ae72cf3ac0011fda4640cdaa23f477

--- a/syncthing.spec
+++ b/syncthing.spec
@@ -1,6 +1,6 @@
 %global debug_package %{nil}
 Name:           syncthing
-Version:        2.0.0
+Version:        2.0.1
 Release:        0
 Summary:        Continuous File Synchronisation
 # syncthing (MPL-2.0) bundles


### PR DESCRIPTION
Bugfix release that shortly followed 2.0. Builds on ABF. 
